### PR TITLE
lots of stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sqlx",
+ "thiserror",
  "tokio",
  "tower-http",
  "tracing",
@@ -2370,18 +2371,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ bcrypt = "0.15.1"
 chrono = "0.4.38"
 config = { version = "0.14.0", features = ["toml"] }
 jsonwebtoken = "9.3.0"
+thiserror = "1.0.63"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.5", features = ["trace"] }
 tracing = { version = "0.1.40", features = ["log"] }

--- a/migrations/20240807234242_api_keys.down.sql
+++ b/migrations/20240807234242_api_keys.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS api_keys;

--- a/migrations/20240807234242_api_keys.up.sql
+++ b/migrations/20240807234242_api_keys.up.sql
@@ -1,0 +1,8 @@
+-- Add up migration script here
+CREATE TABLE IF NOT EXISTS api_keys (
+  id SERIAL PRIMARY KEY,
+  key VARCHAR(255) NOT NULL,
+  user_id INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/migrations/20240808183507_add_nation_name_to_dispatches.down.sql
+++ b/migrations/20240808183507_add_nation_name_to_dispatches.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE dispatches DROP COLUMN nation;

--- a/migrations/20240808183507_add_nation_name_to_dispatches.up.sql
+++ b/migrations/20240808183507_add_nation_name_to_dispatches.up.sql
@@ -1,0 +1,4 @@
+-- Add up migration script here
+ALTER TABLE dispatches ADD COLUMN nation VARCHAR(255);
+UPDATE dispatches SET nation = 'upc_the_founder';
+ALTER TABLE dispatches ALTER COLUMN nation SET NOT NULL;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -10,8 +10,19 @@ pub(crate) struct Args {
     pub(crate) database_password: String,
     pub(crate) log_level: String,
     pub(crate) port: u16,
-    pub(crate) ns_nation: String,
-    pub(crate) ns_password: String,
+    pub(crate) nations: String,
     pub(crate) secret: String,
     pub(crate) telegram_client_key: String,
+}
+
+pub(crate) fn create_nations_map(nations: &str) -> std::collections::HashMap<String, String> {
+    nations
+        .split(',')
+        .map(|nation| {
+            let mut split = nation.split(':');
+            let key = split.next().unwrap().to_string();
+            let value = split.next().unwrap().to_string();
+            (key, value)
+        })
+        .collect()
 }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,9 +1,11 @@
 use crate::core::client::Client;
 use crate::core::error::{ConfigError, Error};
-use crate::types::ns::{Dispatch, EditDispatchParams, NewDispatchParams};
+use crate::types::ns::{Dispatch, EditDispatchParams, NewDispatchParams, RemoveDispatchParams};
+use crate::types::response;
 use crate::utils::auth::User;
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 use sqlx::Row;
+use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 pub(crate) struct AppState {
@@ -16,18 +18,16 @@ impl AppState {
     pub(crate) async fn new(
         database_url: &str,
         user: &str,
-        nation: String,
-        password: String,
+        nations: HashMap<String, String>,
         secret: String,
         telegram_client_key: String,
     ) -> Result<Self, ConfigError> {
         let pool = PgPoolOptions::new()
             .max_connections(5)
             .connect(database_url)
-            .await
-            .map_err(ConfigError::DatabaseConnectionFailure)?;
+            .await?;
 
-        let client = Client::new(user, nation, password, telegram_client_key)?;
+        let client = Client::new(user, nations, telegram_client_key)?;
 
         Ok(AppState {
             pool,
@@ -36,17 +36,83 @@ impl AppState {
         })
     }
 
-    pub(crate) async fn new_dispatch(mut self, params: NewDispatchParams) -> Result<i32, Error> {
-        let dispatch = Dispatch::try_from_new_params(params, &self.client.nation)?;
+    pub(crate) async fn get_dispatch(self, dispatch_id: i32) -> Result<response::Dispatch, Error> {
+        let dispatch = match sqlx::query(
+            "SELECT
+                dispatches.dispatch_id,
+                dispatches.nation,
+                dispatch_content.category,
+                dispatch_content.subcategory,
+                dispatch_content.title,
+                dispatch_content.text,
+                dispatch_content.created_by
+            FROM dispatches
+            JOIN
+                dispatch_content ON dispatch_content.dispatch_id = dispatches.id
+            WHERE dispatches.dispatch_id = $1
+            AND dispatches.is_active = TRUE;",
+        )
+        .bind(dispatch_id)
+        .map(map_dispatch)
+        .fetch_one(&self.pool)
+        .await
+        {
+            Ok(dispatch) => dispatch,
+            Err(sqlx::Error::RowNotFound) => return Err(Error::DispatchNotFound),
+            Err(e) => return Err(Error::SQL(e)),
+        };
+
+        Ok(dispatch)
+    }
+
+    pub(crate) async fn get_dispatches(self) -> Result<Vec<response::DispatchHeader>, Error> {
+        let dispatches = sqlx::query(
+            "SELECT
+                dispatches.dispatch_id,
+                dispatches.nation,
+                dispatch_content.category,
+                dispatch_content.subcategory,
+                dispatch_content.title,
+                dispatch_content.created_by
+            FROM dispatches
+            JOIN
+                dispatch_content ON dispatch_content.dispatch_id = dispatches.id
+            WHERE dispatch_content.id = (
+                SELECT id FROM dispatch_content
+              WHERE dispatch_content.dispatch_id = dispatches.id
+              ORDER BY dispatch_content.id DESC
+              LIMIT 1
+            )
+            AND dispatches.is_active = TRUE;",
+        )
+        .map(map_dispatch_header)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(dispatches)
+    }
+
+    pub(crate) async fn new_dispatch(
+        mut self,
+        params: NewDispatchParams,
+        created_by: &str,
+    ) -> Result<response::DispatchHeader, Error> {
+        if !self.client.nations.contains_key(&params.nation) {
+            return Err(Error::InvalidNation);
+        }
+
+        let dispatch = Dispatch::try_from(params.clone())?;
 
         let dispatch_id = self.client.new_dispatch(dispatch.clone()).await?;
 
-        let id: i32 = sqlx::query("INSERT INTO dispatches (dispatch_id) VALUES ($1) RETURNING id;")
-            .bind(dispatch_id)
-            .map(|row: PgRow| row.get(0))
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Error::SQL)?;
+        let id: i32 = sqlx::query(
+            "INSERT INTO dispatches (dispatch_id, nation) VALUES ($1, $2) RETURNING id;",
+        )
+        .bind(dispatch_id)
+        .bind(dispatch.nation)
+        .map(|row: PgRow| row.get(0))
+        .fetch_one(&self.pool)
+        .await?;
 
         sqlx::query(
             "INSERT INTO dispatch_content (dispatch_id, category, subcategory, title, text, created_by) VALUES ($1, $2, $3, $4, $5, $6);"
@@ -56,29 +122,34 @@ impl AppState {
             .bind(dispatch.subcategory)
             .bind(dispatch.title)
             .bind(dispatch.text)
-            .bind("upc")
+            .bind(created_by)
             .execute(&self.pool)
-            .await
-            .map_err(Error::SQL)?;
+            .await?;
 
-        Ok(dispatch_id)
+        let dispatch_header = response::DispatchHeader {
+            id: dispatch_id,
+            nation: params.nation,
+            category: Some(params.category),
+            subcategory: Some(params.subcategory),
+            title: Some(params.title),
+            created_by: Some(created_by.to_string()),
+        };
+
+        Ok(dispatch_header)
     }
 
-    pub(crate) async fn edit_dispatch(mut self, params: EditDispatchParams) -> Result<i32, Error> {
-        let dispatch = Dispatch::try_from_edit_params(params, &self.client.nation)?;
+    pub(crate) async fn edit_dispatch(
+        mut self,
+        params: EditDispatchParams,
+        created_by: &str,
+    ) -> Result<response::DispatchHeader, Error> {
+        if !self.client.nations.contains_key(&params.nation) {
+            return Err(Error::InvalidNation);
+        }
 
-        let dispatch_id: i32 = match sqlx::query(
-            "SELECT dispatch_id FROM dispatches WhERE is_active = true AND dispatch_id = $1;",
-        )
-        .bind(dispatch.id.unwrap())
-        .map(|row: PgRow| row.get("dispatch_id"))
-        .fetch_one(&self.pool)
-        .await
-        {
-            Ok(id) => id,
-            Err(sqlx::Error::RowNotFound) => return Err(Error::DispatchNotFound),
-            Err(e) => return Err(Error::SQL(e)),
-        };
+        let dispatch = Dispatch::try_from(params.clone())?;
+
+        let dispatch_id = self.get_dispatch_id(&dispatch).await?;
 
         self.client.new_dispatch(dispatch.clone()).await?;
 
@@ -90,12 +161,91 @@ impl AppState {
             .bind(dispatch.subcategory)
             .bind(dispatch.title)
             .bind(dispatch.text)
-            .bind("upc")
+            .bind(created_by)
+            .execute(&self.pool)
+            .await?;
+
+        let dispatch_header = response::DispatchHeader {
+            id: dispatch_id,
+            nation: params.nation,
+            category: Some(params.category),
+            subcategory: Some(params.subcategory),
+            title: Some(params.title),
+            created_by: Some(created_by.to_string()),
+        };
+
+        Ok(dispatch_header)
+    }
+
+    pub(crate) async fn remove_dispatch(
+        mut self,
+        params: RemoveDispatchParams,
+    ) -> Result<response::DispatchHeader, Error> {
+        if !self.client.nations.contains_key(&params.nation) {
+            return Err(Error::InvalidNation);
+        }
+
+        let dispatch = Dispatch::try_from(params.clone())?;
+
+        let dispatch_id = self.get_dispatch_id(&dispatch).await?;
+
+        self.client.delete_dispatch(dispatch.clone()).await?;
+
+        sqlx::query("UPDATE dispatches SET is_active = FALSE WHERE dispatch_id = $1;")
+            .bind(dispatch_id)
+            .execute(&self.pool)
+            .await?;
+
+        let dispatch_header = response::DispatchHeader {
+            id: dispatch_id,
+            nation: params.nation,
+            ..Default::default()
+        };
+
+        Ok(dispatch_header)
+    }
+
+    async fn get_dispatch_id(&self, dispatch: &Dispatch) -> Result<i32, Error> {
+        Ok(
+            match sqlx::query(
+                "SELECT dispatch_id FROM dispatches WhERE is_active = true AND dispatch_id = $1;",
+            )
+            .bind(dispatch.id.unwrap())
+            .map(|row: PgRow| row.get("dispatch_id"))
+            .fetch_one(&self.pool)
+            .await
+            {
+                Ok(id) => id,
+                Err(sqlx::Error::RowNotFound) => return Err(Error::DispatchNotFound),
+                Err(e) => return Err(Error::SQL(e)),
+            },
+        )
+    }
+
+    pub(crate) async fn register_user(
+        &self,
+        nation: &str,
+        password_hash: &str,
+    ) -> Result<User, Error> {
+        if let Err(e) = sqlx::query("INSERT INTO users (username, password_hash) VALUES ($1, $2);")
+            .bind(nation)
+            .bind(password_hash)
             .execute(&self.pool)
             .await
-            .map_err(Error::SQL)?;
+        {
+            return match e {
+                sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                    Err(Error::UserAlreadyExists)
+                }
+                _ => Err(Error::SQL(e)),
+            };
+        }
 
-        Ok(dispatch_id)
+        Ok(User {
+            username: nation.to_string(),
+            password_hash: password_hash.to_string(),
+            claims: sqlx::types::Json(Vec::new()),
+        })
     }
 
     pub(crate) async fn retrieve_user_by_username(
@@ -129,26 +279,37 @@ impl AppState {
         }
     }
 
-    pub(crate) async fn register_user(
+    pub(crate) async fn retrieve_user_by_api_key(
         &self,
-        nation: &str,
-        password_hash: &str,
-    ) -> Result<(), Error> {
-        if let Err(e) = sqlx::query("INSERT INTO users (username, password_hash) VALUES ($1, $2);")
-            .bind(nation)
-            .bind(password_hash)
-            .execute(&self.pool)
-            .await
+        api_key: &str,
+    ) -> Result<Option<User>, Error> {
+        match sqlx::query(
+            "SELECT
+            users.username,
+            users.password_hash,
+            json_agg(permissions.name) AS permissions
+            FROM
+                api_keys
+            JOIN
+                users ON api_keys.user_id = users.id
+            JOIN
+                user_permissions ON users.id = user_permissions.user_id
+            JOIN
+                permissions ON user_permissions.permission_id = permissions.id
+            WHERE
+                key = $1
+            GROUP BY
+                users.id, users.username;",
+        )
+        .bind(api_key)
+        .map(map_user)
+        .fetch_one(&self.pool)
+        .await
         {
-            return match e {
-                sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
-                    Err(Error::UserAlreadyExists)
-                }
-                _ => Err(Error::SQL(e)),
-            };
+            Ok(user) => Ok(Some(user)),
+            Err(sqlx::Error::RowNotFound) => Ok(None),
+            Err(e) => Err(Error::SQL(e)),
         }
-
-        Ok(())
     }
 }
 
@@ -157,5 +318,28 @@ fn map_user(row: PgRow) -> User {
         username: row.get("username"),
         password_hash: row.get("password_hash"),
         claims: row.get("permissions"),
+    }
+}
+
+fn map_dispatch_header(row: PgRow) -> response::DispatchHeader {
+    response::DispatchHeader {
+        id: row.get("dispatch_id"),
+        nation: row.get("nation"),
+        category: row.get("category"),
+        subcategory: row.get("subcategory"),
+        title: row.get("title"),
+        created_by: row.get("created_by"),
+    }
+}
+
+fn map_dispatch(row: PgRow) -> response::Dispatch {
+    response::Dispatch {
+        id: row.get("dispatch_id"),
+        nation: row.get("nation"),
+        category: row.get("category"),
+        subcategory: row.get("subcategory"),
+        title: row.get("title"),
+        text: row.get("text"),
+        created_by: row.get("created_by"),
     }
 }

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -29,7 +29,7 @@ pub(crate) async fn sign_in(
         false => return Err(Error::Unauthorized),
     }
 
-    let token = encode_jwt(user.username, &state.secret)?;
+    let token = encode_jwt(user, &state.secret)?;
 
     Ok(Json(token))
 }
@@ -40,11 +40,11 @@ pub(crate) async fn register(
 ) -> Result<Json<String>, Error> {
     let password_hash = bcrypt::hash(&user_data.password, 12).map_err(Error::Bcrypt)?;
 
-    state
+    let user = state
         .register_user(&user_data.username, &password_hash)
         .await?;
 
-    let token = encode_jwt(user_data.username, &state.secret)?;
+    let token = encode_jwt(user, &state.secret)?;
 
     Ok(Json(token))
 }

--- a/src/routes/dispatch.rs
+++ b/src/routes/dispatch.rs
@@ -1,40 +1,73 @@
 use crate::core::error::Error;
 use crate::core::state::AppState;
-use axum::extract::{Json, State};
+use axum::extract::{Json, Path, State};
+use axum::Extension;
 use tracing::instrument;
 
-use crate::types::ns::{Dispatch, EditDispatchParams, NewDispatchParams, RemoveDispatchParams};
+use crate::types::ns::{EditDispatchParams, NewDispatchParams, RemoveDispatchParams};
+use crate::types::response::{Dispatch, DispatchHeader};
+use crate::utils::auth::User;
 
 #[instrument(skip(state))]
+pub(crate) async fn get_dispatch(
+    State(state): State<AppState>,
+    Path(id): Path<i32>,
+) -> Result<Json<Dispatch>, Error> {
+    let dispatch = state.get_dispatch(id).await?;
+
+    Ok(Json(dispatch))
+}
+
+#[instrument(skip(state))]
+pub(crate) async fn get_dispatches(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<DispatchHeader>>, Error> {
+    let dispatches = state.get_dispatches().await?;
+
+    Ok(Json(dispatches))
+}
+
+#[instrument(skip(state, user))]
 pub(crate) async fn post_dispatch(
     State(state): State<AppState>,
+    Extension(user): Extension<User>,
     Json(params): Json<NewDispatchParams>,
-) -> Result<String, Error> {
-    let dispatch_id = state.new_dispatch(params).await?;
+) -> Result<Json<DispatchHeader>, Error> {
+    if !user.claims.contains(&"dispatches.create".to_string()) {
+        return Err(Error::Unauthorized);
+    }
 
-    Ok(format!("Dispatch: {} added", dispatch_id))
+    let dispatch = state.new_dispatch(params, &user.username).await?;
+
+    Ok(Json(dispatch))
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, user))]
 pub(crate) async fn edit_dispatch(
     State(state): State<AppState>,
+    Extension(user): Extension<User>,
     Json(params): Json<EditDispatchParams>,
-) -> Result<String, Error> {
-    let dispatch_id = state.edit_dispatch(params).await?;
+) -> Result<Json<DispatchHeader>, Error> {
+    if !user.claims.contains(&"dispatches.edit".to_string()) {
+        return Err(Error::Unauthorized);
+    }
 
-    Ok(format!("Dispatch: {} edited", dispatch_id))
+    let dispatch = state.edit_dispatch(params, &user.username).await?;
+
+    Ok(Json(dispatch))
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, user))]
 pub(crate) async fn remove_dispatch(
-    State(mut state): State<AppState>,
+    State(state): State<AppState>,
+    Extension(user): Extension<User>,
     Json(params): Json<RemoveDispatchParams>,
-) -> Result<String, Error> {
-    tracing::debug!("Creating dispatch from params");
-    let dispatch = Dispatch::from_remove_params(params, &state.client.nation);
+) -> Result<Json<DispatchHeader>, Error> {
+    if !user.claims.contains(&"dispatches.delete".to_string()) {
+        return Err(Error::Unauthorized);
+    }
 
-    tracing::debug!("Removing dispatch");
-    state.client.delete_dispatch(dispatch).await?;
+    let dispatch = state.remove_dispatch(params).await?;
 
-    Ok("Dispatch removed".to_string())
+    Ok(Json(dispatch))
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod ns;
+pub(crate) mod response;

--- a/src/types/ns.rs
+++ b/src/types/ns.rs
@@ -11,7 +11,7 @@ pub(crate) enum FactbookCategory {
 }
 
 impl FactbookCategory {
-    fn to_tuple(&self) -> (i32, i32) {
+    fn to_tuple(&self) -> (i16, i16) {
         match self {
             FactbookCategory::Factbook(subcategory) => match subcategory {
                 FactbookSubcategory::Overview => (1, 100),
@@ -51,10 +51,10 @@ impl FactbookCategory {
     }
 }
 
-impl TryFrom<(i32, i32)> for FactbookCategory {
+impl TryFrom<(i16, i16)> for FactbookCategory {
     type Error = Error;
 
-    fn try_from((category, subcategory): (i32, i32)) -> Result<Self, Self::Error> {
+    fn try_from((category, subcategory): (i16, i16)) -> Result<Self, Self::Error> {
         match category {
             1 => match subcategory {
                 100 => Ok(FactbookCategory::Factbook(FactbookSubcategory::Overview)),
@@ -206,7 +206,7 @@ impl std::fmt::Display for Mode {
 pub(crate) struct Dispatch {
     #[serde(rename = "dispatchid", skip_serializing_if = "Option::is_none")]
     pub(crate) id: Option<i32>,
-    nation: String,
+    pub(crate) nation: String,
     #[serde(rename = "c")]
     command: String,
     #[serde(rename = "dispatch")]
@@ -216,9 +216,9 @@ pub(crate) struct Dispatch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) text: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) category: Option<i32>,
+    pub(crate) category: Option<i16>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) subcategory: Option<i32>,
+    pub(crate) subcategory: Option<i16>,
     mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     token: Option<String>,
@@ -269,13 +269,14 @@ impl Dispatch {
     pub(crate) fn set_token(&mut self, token: String) {
         self.token = Some(token);
     }
+}
 
-    pub(crate) fn try_from_new_params(
-        params: NewDispatchParams,
-        nation: &str,
-    ) -> Result<Self, Error> {
+impl TryFrom<NewDispatchParams> for Dispatch {
+    type Error = Error;
+
+    fn try_from(params: NewDispatchParams) -> Result<Self, Error> {
         Ok(Dispatch::new(
-            nation.to_string(),
+            params.nation,
             Command::Dispatch,
             DispatchAction::Add,
             Some(params.title),
@@ -286,13 +287,14 @@ impl Dispatch {
             ))?),
         ))
     }
+}
 
-    pub(crate) fn try_from_edit_params(
-        params: EditDispatchParams,
-        nation: &str,
-    ) -> Result<Self, Error> {
+impl TryFrom<EditDispatchParams> for Dispatch {
+    type Error = Error;
+
+    fn try_from(params: EditDispatchParams) -> Result<Self, Error> {
         Ok(Dispatch::new(
-            nation.to_string(),
+            params.nation,
             Command::Dispatch,
             DispatchAction::Edit(params.id),
             Some(params.title),
@@ -303,38 +305,45 @@ impl Dispatch {
             ))?),
         ))
     }
+}
 
-    pub(crate) fn from_remove_params(params: RemoveDispatchParams, nation: &str) -> Self {
-        Dispatch::new(
-            nation.to_string(),
+impl TryFrom<RemoveDispatchParams> for Dispatch {
+    type Error = Error;
+
+    fn try_from(params: RemoveDispatchParams) -> Result<Self, Error> {
+        Ok(Dispatch::new(
+            params.nation,
             Command::Dispatch,
             DispatchAction::Remove(params.id),
             None,
             None,
             None,
-        )
+        ))
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub(crate) struct NewDispatchParams {
+    pub(crate) nation: String,
     pub(crate) title: String,
     pub(crate) text: String,
-    pub(crate) category: i32,
-    pub(crate) subcategory: i32,
+    pub(crate) category: i16,
+    pub(crate) subcategory: i16,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub(crate) struct EditDispatchParams {
+    pub(crate) nation: String,
     pub(crate) id: i32,
     pub(crate) title: String,
     pub(crate) text: String,
-    pub(crate) category: i32,
-    pub(crate) subcategory: i32,
+    pub(crate) category: i16,
+    pub(crate) subcategory: i16,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub(crate) struct RemoveDispatchParams {
+    pub(crate) nation: String,
     pub(crate) id: i32,
 }
 

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -1,0 +1,26 @@
+use serde::Serialize;
+
+#[derive(Default, Serialize)]
+pub(crate) struct DispatchHeader {
+    pub(crate) id: i32,
+    pub(crate) nation: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) category: Option<i16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) subcategory: Option<i16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) created_by: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct Dispatch {
+    pub(crate) id: i32,
+    pub(crate) nation: String,
+    pub(crate) category: i16,
+    pub(crate) subcategory: i16,
+    pub(crate) title: String,
+    pub(crate) text: String,
+    pub(crate) created_by: String,
+}

--- a/src/utils/ratelimiter.rs
+++ b/src/utils/ratelimiter.rs
@@ -2,7 +2,6 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::{sleep, Duration, Instant};
-use tracing;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Ratelimiter {
@@ -119,11 +118,6 @@ impl Ratelimiter {
                 sleep(self.recruitment_telegram_cooldown - elapsed).await;
             }
         }
-    }
-
-    pub(crate) async fn get_last_telegram_timestamp(&self) -> Option<Instant> {
-        let last_telegram_sent = self.last_telegram_sent.read().await;
-        *last_telegram_sent
     }
 
     pub(crate) fn telegram_cooldown(&self) -> Duration {


### PR DESCRIPTION
- dispatches can be posted from multiple nations (nation is a new parameter for new, edited, and deleted dispatches)
- dispatch and dispatches GET endpoints
- api_keys for auth as alternative to tokens
- telegram cooldown increased by 50ms
- dispatch DELETE endpoint
- new and edited dispatches properly record the user who made the changes
- errors and configerrors reworked with thiserror to avoid needing to use .map_err everywhere